### PR TITLE
added the 1.1 team section to the documentation

### DIFF
--- a/docs/Milestone_1/sections/section1/subsections/1.1.adoc
+++ b/docs/Milestone_1/sections/section1/subsections/1.1.adoc
@@ -1,6 +1,6 @@
 == *Informative Part*
 
-=== Team
+=== *Team*
 
 The Official Lost and Found (LnF) project is organized into four functional teams and two project managers. All team members listed below are active contributors to the project and are considered confirmed partners because they are directly involved in planning, implementation, documentation, and delivery.
 


### PR DESCRIPTION
## Summary

Added the `1.1 Team` section in AsciiDoc format for the Lost and Found project documentation.

## What was added

* Current project team structure (managers + 4 teams)
* Team members grouped by functional team
* Clarification of the difference between **team members** and **partners**
* Current confirmed partners (project team members)
* Possible external partners not yet confirmed and their possible roles
* Note explaining why customers/users are not automatically considered partners



## Notes

* External partners are listed as possible/not yet confirmed.
* The section is formatted to stay consistent with the project’s AsciiDoc documentation style.
