### PR TITLE
feat: enhance tab navigation with accessibility (closes #166)

### DIFF
--- a/Lost-and-Found-App/src/pages/HomePage.tsx
+++ b/Lost-and-Found-App/src/pages/HomePage.tsx
@@ -39,24 +39,51 @@ export default function HomePage() {
 
   return (
     <div style={{ maxWidth: 900, margin: "40px auto", padding: "0 16px", fontFamily: "system-ui" }}>
-      <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
+      <div role="tablist" style={{ display: "flex", gap: 8, marginBottom: 16, justifyContent: "center" }}>
         <button
+          role="tab"
+          aria-selected={tab === "Lost"}
           onClick={() => setTab("Lost")}
-          style={{ padding: "30px 50px", background: "#D75858", cursor: "pointer" }}
+          style={{
+            padding: "30px 50px",
+            background: "#D75858",
+            cursor: "pointer",
+            fontWeight: tab === "Lost" ? 700 : 400,
+            border: "none",
+            borderBottom: tab === "Lost" ? "4px solid #7a1a1a" : "4px solid transparent",
+          }}
         >
-          Lost
+          &#10007; Lost
         </button>
         <button
+          role="tab"
+          aria-selected={tab === "Claimed"}
           onClick={() => setTab("Claimed")}
-          style={{ padding: "30px 50px", background: "#DACD68", cursor: "pointer" }}
+          style={{
+            padding: "30px 50px",
+            background: "#DACD68",
+            cursor: "pointer",
+            fontWeight: tab === "Claimed" ? 700 : 400,
+            border: "none",
+            borderBottom: tab === "Claimed" ? "4px solid #7a6e1a" : "4px solid transparent",
+          }}
         >
-          Claimed
+          &#10003; Claimed
         </button>
         <button
+          role="tab"
+          aria-selected={tab === "Returned"}
           onClick={() => setTab("Returned")}
-          style={{ padding: "30px 50px", background: "#7FDE67", cursor: "pointer" }}
+          style={{
+            padding: "30px 50px",
+            background: "#7FDE67",
+            cursor: "pointer",
+            fontWeight: tab === "Returned" ? 700 : 400,
+            border: "none",
+            borderBottom: tab === "Returned" ? "4px solid #2a6e1a" : "4px solid transparent",
+          }}
         >
-          Returned
+          &#8617; Returned
         </button>
       </div>
 
@@ -98,7 +125,7 @@ function ClaimTab({ items }: { items: Item[] }) {
 function ReturnTab() {
   return (
     <>
-      <h2>Found Items</h2>
+      <h2>Returned Items</h2>
       <p>Show items users reported as returned.</p>
     </>
   );


### PR DESCRIPTION
Could not resolve merge conflict in PR #240 so I created another branch with the same proposed changes implemented.


## Summary

This PR implements the **prototype "Found" tab** as part of the Early Homepage UI Proof of Concept.

The goal of this task was to demonstrate how users would view items that have been reported as **found**, using mock data and without backend integration.

The tab is fully functional from a UI perspective and allows users to switch between tabs and view placeholder found items.

---

## Changes Implemented

- Added **Found tab** to the homepage tab navigation
- Implemented **tab switching functionality** so that selecting the Found tab updates the displayed content
- Added **3 placeholder found item cards** for UI demonstration
- Each card includes:
  - Image container with placeholder fallback
  - Item title
  - Short description
  - Date label
  - Location label
  - Status indicator

All data displayed is **static/mock data**, since this task focuses only on frontend UI behavior.

---

## UI Behavior

- The **Found tab is visible and selectable** in the homepage navigation
- Clicking the tab **updates the displayed content correctly**
- The page shows **multiple placeholder found items**
- Cards visually reflect the **Found item status**

<img width="817" height="794" alt="Screenshot 2026-03-07 at 4 42 39 PM" src="https://github.com/user-attachments/assets/7004820b-2548-47ff-9acc-e9c315380d03" />

---

## Testing

Verified the following:

- Found tab appears correctly in the navigation
- Tab switching updates the content without page reload
- Placeholder item cards render correctly
- No runtime errors occur when switching tabs
- Layout remains consistent with the homepage UI prototype

---

## Related Issue

Closes / Implements: **#166**

Parent Issue: **#155 – Early Homepage UI Proof of Concept**